### PR TITLE
Fix Get-FileHash

### DIFF
--- a/HAFNIUM-Exchange-IOC.ps1
+++ b/HAFNIUM-Exchange-IOC.ps1
@@ -204,7 +204,7 @@ Foreach ($p in $webShellPaths) {
   
   foreach ($hash in $shellHashes){ 
 
-  if ($file | Get-FileHash -eq  "$hash"){
+  if (($file | Get-FileHash).Hash -eq  "$hash"){
 
      $shellHits += $file.FullName
      break


### PR DESCRIPTION
Fix Get-FileHash: A parameter cannot be found that matches parameter name 'eq'